### PR TITLE
fix: hide vertical scroll on empty editor page

### DIFF
--- a/src/app/editor/editor.component.css
+++ b/src/app/editor/editor.component.css
@@ -54,7 +54,6 @@ sketch-container {
   height: 100%;
   justify-content: center;
   top: 64px;
-  overflow: scroll;
   position: absolute;
 }
 

--- a/src/app/editor/viewer/lib/sketch-container.component.ts
+++ b/src/app/editor/viewer/lib/sketch-container.component.ts
@@ -34,6 +34,7 @@ import { SketchData, SketchService } from './sketch.service';
     height: 100%;
     min-height: 100%;
     position: absolute;
+    overflow: scroll;
   }
 
   sketch-layer {


### PR DESCRIPTION
Should fix the https://github.com/manekinekko/xlayers/issues/10

I think, that you don't need to add the `overflow` property to the whole component, even if it's still has no sketch uploaded (which, actually, was the reason of issue), and user want to see scroll only after the uploading


P.S. My first commit to the OSS project, not related to the Valor :dancer: 