### PR TITLE
fix: auto select the layout toggle button when selecting a layer

### DIFF
--- a/src/app/editor/layer-settings/settings-container/settings-container.component.ts
+++ b/src/app/editor/layer-settings/settings-container/settings-container.component.ts
@@ -1,5 +1,6 @@
-import { Component, OnInit, ViewChild, ElementRef } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Store } from '@ngxs/store';
+import { UiState } from '../../../core/state';
 
 @Component({
   selector: 'sketch-settings-container',
@@ -11,7 +12,7 @@ import { Store } from '@ngxs/store';
         [value]="currentSettingView">
 
         <mat-button-toggle value="1">
-          <mat-icon>open_with</mat-icon>
+          <mat-icon [class.mat-button-toggle-checked]="currentSettingView === 1">open_with</mat-icon>
         </mat-button-toggle>
         <mat-button-toggle value="2">
           <mat-icon>format_paint</mat-icon>
@@ -29,22 +30,31 @@ import { Store } from '@ngxs/store';
     </section>
   `,
   styles: [
+      `
+      .mat-elevation-z0 {
+        box-shadow: none;
+      }
+
+      .mat-button-toggle-checked {
+        color: #EE4743;
+      }
     `
-    .mat-elevation-z0 {
-      box-shadow: none;
-    }
-    .mat-button-toggle-checked {
-      color: #EE4743;
-    }
-  `
   ]
 })
 export class SettingsContainerComponent implements OnInit {
-  currentSettingView;
+  currentSettingView: number;
+  previousLayout: any = null;
 
   constructor(private store: Store) {}
 
   ngOnInit() {
-    this.currentSettingView = 1;
+    this.store.select(UiState.currentLayer).subscribe(currentLayer => {
+      if (currentLayer) {
+        if (!this.previousLayout || this.previousLayout.do_objectID !== currentLayer.do_objectID) {
+          this.currentSettingView = 1;
+          this.previousLayout = currentLayer;
+        }
+      }
+    });
   }
 }


### PR DESCRIPTION
Potential fix for : https://github.com/manekinekko/xlayers/issues/2

I'm not sure, that I completely get this task, but, trying to fix it in a more user-friendly way.

**Current state of app**: When user toggles the layer on sketch, or somewhere, he is on the layers-position tab (but, the button doesn't marked as active)

[!https://user-images.githubusercontent.com/1699357/40581355-97467ce0-6156-11e8-9ede-a4867235b118.png]

Also, if you switch tab, for example. to layer-colors, and then, toggle to another layer, you will stay at the layer-colors tab (which, in my opinion is not totally correct, and we have to switch user back to the first tab -> layers-postion)

In this PR I've fixed both issues, with not active css-styles, and also, add the switch to first tab after changing the layer


@manekinekko  if it's not correct,  please, describe the way, you want to see it, and I'll try to fix it :)